### PR TITLE
default output filename to threadtracer.$PID.json

### DIFF
--- a/threadtracer.c
+++ b/threadtracer.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <stdio.h>
+#include <unistd.h>
 #include <string.h>
 #include <pthread.h>
 
@@ -145,8 +146,22 @@ int tt_stamp( const char* cat, const char* tag, const char* phase )
 }
 
 
-int tt_report( const char* oname )
+int tt_report( const char* user_oname )
 {
+    char default_oname[256];
+    const char *oname;
+    
+    if (!user_oname)
+    {
+        long pid = (long)getpid();
+        snprintf(default_oname, 256, "threadtracer.%ld.json", pid);
+        oname = default_oname;
+    }
+    else
+    {
+        oname = user_oname;
+    }
+    
 	if ( numthreads == 0 )
 	{
 		fprintf( stderr, "ThreadTracer: Nothing to report, 0 threads signed in.\n" );


### PR DESCRIPTION
Being able to compare subsequent runs without overwrite is very useful, and I realized there was an opportunity to put this code in the lib if `tt_report(NULL)` is called.