### PR TITLE
Fix c compilation, warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ void draw_all(void)
 
 // When you are done profiling, typically at program end, or earlier, you can generate the profile report.
 
-tt_report();
+tt_report(NULL);
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ ThreadTracer is an inline profiler that is special in the following ways:
 #include <threadtracer.h>
 
 // Each thread that will be generating profiling events needs to be made known to the system.
-// If you sign in with threadid -1, the threadid of calling thread will be used.
+// If you sign in with threadid TT_CALLING_THREAD, the threadid of calling thread will be used.
 
-tt_signin( -1, "mainthread" );
+tt_signin( TT_CALLING_THREAD, "mainthread" );
 
 // C Programs need to wrap sections of code with a begin and end macro.
 

--- a/threadtracer.h
+++ b/threadtracer.h
@@ -6,6 +6,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define TT_CALLING_THREAD (struct pthread*)-1
+
 extern int tt_signin( pthread_t tid, const char* threadname );
 
 extern int tt_stamp( const char* cat, const char* tag, const char* phase );

--- a/threadtracer.h
+++ b/threadtracer.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-#define TT_CALLING_THREAD (struct pthread*)-1
+#define TT_CALLING_THREAD (pthread_t)(-1)
 
 extern int tt_signin( pthread_t tid, const char* threadname );
 


### PR DESCRIPTION
This change introduces TT_CALLING_THREAD macro instead of using -1 which is necessary to get full warnings pass.

Tested on x86, amd64 for:
 - clang 10 linux
 - gcc 10 linux
 - clang 8 freebsd

Also fixes C compilation.